### PR TITLE
crystal-1.0.0: replace deprecated JSON.mapping with JSON::Serializable

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,6 +7,10 @@ authors:
 description: |
   Twilio API wrapper for Crystal.
 
-crystal: 0.35.1
+crystal: 1.0.0
 
 license: MIT
+
+dependencies:
+  connect-proxy:
+    github: spider-gazelle/connect-proxy

--- a/src/twilio.cr
+++ b/src/twilio.cr
@@ -1,6 +1,7 @@
 require "http/client"
 require "json"
 
+require "./twilio/api"
 require "./twilio/**"
 
 module Twilio

--- a/src/twilio/api/accounts.cr
+++ b/src/twilio/api/accounts.cr
@@ -1,0 +1,22 @@
+module Twilio
+  class Api::Accounts < Api
+
+    def list
+      response = @http_client.get("/2010-04-01/Accounts.json")
+      handleResponse(response)
+    end
+
+    def fetch(sid = @account_sid)
+      response = @http_client.get("/2010-04-01/Accounts/#{sid}.json")
+
+      handleResponse(response)
+    end
+
+    def balance(sid = @account_sid)
+      response = @http_client.get("/2010-04-01/Accounts/#{sid}/Balance.json")
+
+      handleResponse(response)
+    end
+
+  end
+end

--- a/src/twilio/api/calls.cr
+++ b/src/twilio/api/calls.cr
@@ -1,6 +1,6 @@
 module Twilio
   class Api::Calls < Api
-    def create(from = nil, to = nil, url = nil, applicationSid = nil, method = nil, fallbackUrl = nil, fallbackMethod = nil, statusCallback = nil, statusCallbackEvent = nil, statusCallbackMethod = nil, sendDigits = nil, timeout = nil, record = nil, recordingChannels = nil, recordingStatusCallback = nil, recordingStatusCallbackMethod = nil, recordingStatusCallbackEvent = nil, sipAuthUsername = nil, sipAuthPassword = nil, trim = nil, callerId = nil, machineDetection = nil, machineDetectionTimeout = nil, machineDetectionSpeechThreshold = nil, machineDetectionSpeechEndThreshold = nil, machineDetectionSilenceTimeout = nil)
+    def create(from = nil, to = nil, url = nil, applicationSid = nil, method = nil, fallbackUrl = nil, fallbackMethod = nil, statusCallback = nil, statusCallbackEvent = nil, statusCallbackMethod = nil, sendDigits = nil, timeout = nil, record = nil, recordingChannels = nil, recordingStatusCallback = nil, recordingStatusCallbackMethod = nil, recordingStatusCallbackEvent = nil, sipAuthUsername = nil, sipAuthPassword = nil, trim = nil, callerId = nil, machineDetection = nil, machineDetectionTimeout = nil, machineDetectionSpeechThreshold = nil, machineDetectionSpeechEndThreshold = nil, machineDetectionSilenceTimeout = nil, twiml = nil)
       params = Hash(String, String).new
       params["To"] = to
       params["From"] = from
@@ -28,6 +28,7 @@ module Twilio
       params["MachineDetectionSpeechThreshold"] = machineDetectionSpeechThreshold if machineDetectionSpeechThreshold
       params["MachineDetectionSpeechEndThreshold"] = machineDetectionSpeechEndThreshold if machineDetectionSpeechEndThreshold
       params["MachineDetectionSilenceTimeout"] = machineDetectionSilenceTimeout if machineDetectionSilenceTimeout
+      params["Twiml"] = twiml if twiml
 
       response = @http_client.post("/2010-04-01/Accounts/#{@account_sid}/Calls.json", form: params)
 

--- a/src/twilio/client.cr
+++ b/src/twilio/client.cr
@@ -1,10 +1,12 @@
+require "connect-proxy"
+
 module Twilio
   class Client
     Host = URI.parse("https://api.twilio.com")
     getter account_sid
 
-    def initialize(@account_sid : String, auth_token)
-      @http_client = HTTP::Client.new(Host)
+    def initialize(@account_sid : String, auth_token, proxy = false)
+      @http_client = proxy ? ConnectProxy::HTTPClient.new(Host) : HTTP::Client.new(Host)
       @http_client.basic_auth(account_sid, auth_token)
     end
 

--- a/src/twilio/client.cr
+++ b/src/twilio/client.cr
@@ -10,6 +10,10 @@ module Twilio
       @http_client.basic_auth(account_sid, auth_token)
     end
 
+    def accounts
+      @accounts ||= Api::Accounts.new(@http_client, @account_sid)
+    end
+
     def messages
       @messages ||= Api::Messages.new(@http_client, @account_sid)
     end

--- a/src/twilio/error.cr
+++ b/src/twilio/error.cr
@@ -1,10 +1,13 @@
 module Twilio
   class Error < Exception
     class Mapping
-      JSON.mapping(
-        message: String,
-        status: Int32
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "message")]
+      property message : String
+
+      @[JSON::Field(key: "status")]
+      property status : Int32
     end
   end
 end


### PR DESCRIPTION
this PR makes the twilio library compatible with crystal 1.0.0, because JSON.mapping was marked deprecated in 0.35.1 (see https://crystal-lang.org/api/0.35.1/JSON.html#macro-summary) and removed in 1.0.0