### PR TITLE
Swap out JSON.mapping for JSON::Serializable.

### DIFF
--- a/src/twilio/error.cr
+++ b/src/twilio/error.cr
@@ -1,10 +1,10 @@
 module Twilio
   class Error < Exception
     class Mapping
-      JSON.mapping(
-        message: String,
-        status: Int32
-      )
+      include JSON::Serializable
+
+      property message : String
+      property status : Int32
     end
   end
 end


### PR DESCRIPTION
Fixes #2

I noticed that #1 also fixes this, but that PR seems to add a lot of additional stuff. This is more geared for breaking out just that part to allow the shard to compile with the latest Crystal.